### PR TITLE
Add support for Docker Registry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,10 @@
+docker formula
+==============
+
+0.1.0 (2014-12-29)
+
+- Add support for Docker registry with Amazon S3 support for storage
+
+0.0.1 (2013-10-15)
+
+- Initial version

--- a/README.rst
+++ b/README.rst
@@ -19,3 +19,11 @@ Available states
 ----------
 
 Install and run Docker
+
+
+``docker.registry``
+-------------------
+
+Run a Docker container to start the registry service using AWS S3 to store the images.
+
+It requires the docker state and the `python-formula <https://github.com/TeamLovely/python-formula>`_.

--- a/docker/files/upstart.conf
+++ b/docker/files/upstart.conf
@@ -1,0 +1,17 @@
+{% from "docker/map.jinja" import registry with context %}
+{% from "docker/map.jinja" import amazon with context %}
+
+description "{{ registry.description }}"
+start on runlevel [2345]
+stop on runlevel [06]
+
+exec docker run \
+         -e SETTINGS_FLAVOR={{ amazon.settings_flavor }} \
+         -e AWS_BUCKET={{ amazon.aws_bucket }} \
+         -e AWS_KEY={{ amazon.aws_key }} \
+         -e AWS_SECRET={{ amazon.aws_secret }} \
+         -e STORAGE_PATH={{ amazon.storage_path }} \
+         -e SEARCH_BACKEND={{ registry.search_backend }} \
+         -p {{ registry.port }}:5000 \
+         --restart="{{ registry.restart }}" \
+         registry

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -9,7 +9,7 @@ docker-dependencies:
       - ca-certificates
       - lxc
 
-docker_repo:
+docker-repo:
     pkgrepo.managed:
       - repo: 'deb http://get.docker.io/ubuntu docker main'
       - file: '/etc/apt/sources.list.d/docker.list'
@@ -24,5 +24,7 @@ lxc-docker:
     - require:
       - pkg: docker-dependencies
 
-docker:
-  service.running
+docker-service:
+  service.running:
+    - name: docker
+    - enable: True

--- a/docker/map.jinja
+++ b/docker/map.jinja
@@ -1,0 +1,15 @@
+{% set registry = salt['grains.filter_by']({
+    'default': {
+        'description': 'Docker Registry',
+        'port': '5000',
+        'restart': 'no',
+        'search_backend': 'sqlalchemy'
+    },
+}, merge=salt['pillar.get']('registry:lookup')) %}
+
+{% set amazon = salt['grains.filter_by']({
+    'default': {
+        'settings_flavor': 's3',
+        'storage_path': '/registry'
+    },
+}, merge=salt['pillar.get']('registry:lookup:amazon')) %}

--- a/docker/registry.sls
+++ b/docker/registry.sls
@@ -1,0 +1,30 @@
+file-registry-upstart-conf:
+  file.managed:
+    - name: /etc/init/registry.conf
+    - source: salt://docker/files/upstart.conf
+    - mode: 700
+    - user: root
+    - template: jinja
+    - require:
+      - cmd: cmd-registry-image-pull
+
+cmd-registry-image-pull:
+  cmd.run:
+    - name: docker pull registry
+    - require:
+      - service: docker-service
+
+service-registry:
+  service.running:
+    - name: registry
+    - enable: True
+    - watch:
+      - file: file-registry-upstart-conf
+    - require:
+      - pip: pip-sqlalchemy
+
+pip-sqlalchemy:
+  pip.installed:
+    - name: sqlalchemy
+    - require:
+      - pkg: python2

--- a/pillar.example
+++ b/pillar.example
@@ -1,0 +1,7 @@
+registry:
+  lookup:
+    restart: 'always'
+    amazon:
+      aws_bucket: 'my-registry'
+      aws_key: 'ABCDEFGHIJK123456789'
+      aws_secret: 'AbcD+efG-HIjK1+++23456+789'


### PR DESCRIPTION
This formula adds the support for Docker Registry.

It uses SQLAlchemy as the search backend, Amazon S3 to store the images, and
starts the process using upstart.